### PR TITLE
Update consonants.tsv

### DIFF
--- a/pkg/transcriptionsystems/bipa/consonants.tsv
+++ b/pkg/transcriptionsystems/bipa/consonants.tsv
@@ -1,4 +1,5 @@
 GRAPHEME	PHONATION	PLACE	MANNER	ALIAS	EXTRA	NOTE
+z̰	voiced	alveolar	fricative		creakiness:creaky, airstream:sibilant
 r̠̙	voiced	alveolar	trill		tongue_root:retracted-tongue-root,relative_articulation:retracted	
 ɺ̪̪	voiced	dental	tap		airstream:lateral	
 ɹ̪	voiced	dental	approximant			


### PR DESCRIPTION
The outstanding sound in LAPSyD. I've dealt with this the same way as other coronals marked as unspecified in LAPSyD by using the symbol without diacritic, i.e. alveolar.