### PR TITLE
fixes #116

### DIFF
--- a/pkg/transcriptionsystems/bipa/consonants.tsv
+++ b/pkg/transcriptionsystems/bipa/consonants.tsv
@@ -228,6 +228,7 @@ l̂	voiced	alveolo-palatal	approximant	+	airstream:lateral	Alias used in some tr
 ȵ	voiced	alveolo-palatal	nasal			
 n̂	voiced	alveolo-palatal	nasal	+		Alias used in some transcription systems.
 ȵ̊	voiced	alveolo-palatal	nasal		voicing:devoiced	
+ȵ̥	voiced	alveolo-palatal	nasal	+	voicing:devoiced	
 ᶀ	voiced	bilabial	stop	+	palatalization:palatalized	IPA extensions supplement
 ᶆ	voiced	bilabial	nasal	+	palatalization:palatalized	IPA extensions supplement
 ᶈ	voiceless	bilabial	stop	+	palatalization:palatalized	IPA extensions supplement

--- a/pkg/transcriptionsystems/bipa/markers.tsv
+++ b/pkg/transcriptionsystems/bipa/markers.tsv
@@ -5,3 +5,4 @@ _	boundary	morpheme
 →	boundary	morpheme		
 ←	boundary	morpheme		
 ∼	nasality	nasalized		This character is being used to represent a nasal element in alignments, serving as a placeholder in nasal vowels, so they can be aligned.
+Ø				This character is used to represent null-sounds.


### PR DESCRIPTION
This fixes our issue #116, where I noted that the procedure is not yielding the same output whether you parse from a grapheme or from a sound's name. The way to deal with this is to add an alias. 

```python
In [2]: bipa = CLTS().bipa

In [3]: bipa["devoiced voiced alveolo-palatal nasal consonant"]
Out[3]: <pyclts.models.Consonant: devoiced voiced alveolo-palatal nasal consonant>

In [4]: bipa["devoiced voiced alveolo-palatal nasal consonant"].s
Out[4]: 'ȵ̊'

In [5]: bipa["ȵ̥"].s
Out[5]: 'ȵ̊'

```