### PR TITLE
Update consonants.tsv

### DIFF
--- a/pkg/transcriptionsystems/bipa/consonants.tsv
+++ b/pkg/transcriptionsystems/bipa/consonants.tsv
@@ -414,7 +414,7 @@ l̪̍	voiced	dental	approximant	+	syllabicity:syllabic,airstream:lateral
 ɦ	voiced	glottal	fricative			
 h̬	voiced	glottal	fricative	+		Check source.
 h	voiceless	glottal	fricative			
-h͓	voiceless	glottal	fricative		articulation:with-friction
+h͓	voiceless	glottal	fricative		friction:with-friction
 h̃	voiceless	glottal	fricative		nasalization:nasalized	Check with source.
 ʔ	voiceless	glottal	stop			
 ʔʷ	voiceless	glottal	stop		labialization:labialized	


### PR DESCRIPTION
One segment [h͓] was incorrectly assigned the feature `articulation:with-friction`, which is invalid according to line 225 [here](https://github.com/cldf-clts/clts/blob/master/pkg/transcriptionsystems/features.json). Reassigned as containing rather the consonant feature `friction:with-friction`, which is valid.