### PR TITLE
Update diacritics.tsv

### DIFF
--- a/pkg/transcriptionsystems/bipa/diacritics.tsv
+++ b/pkg/transcriptionsystems/bipa/diacritics.tsv
@@ -41,7 +41,7 @@ GRAPHEME	TYPE	FEATURE	VALUE	ALIAS	TYPOGRAPHY	NOTE
 ◌̽	consonant	relative_articulation	mid-centralized			
 ◌̟	consonant	relative_articulation	advanced			
 ◌̠	consonant	relative_articulation	retracted			
-◌͉	consonant	release	unreleased	+		
+◌͉	consonant	articulation	weak			
 ◌̚	consonant	release	unreleased			
 ◌ˡ	consonant	release	with-lateral-release			
 ◌ᵊ	consonant	release	with-mid-central-vowel-release			


### PR DESCRIPTION
U+0349 now used for weak articulation, not as alias for unreleased